### PR TITLE
fix(ci): restore CI after pnpm v11 / clob-client v5 / TS 6.0 updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: [main]
 
-    permissions:
+permissions:
   contents: read
 
 jobs:

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "pino": "^10.0.0",
     "pino-pretty": "^13.0.0",
     "socket.io-client": "^4.8.1",
+    "viem": "^2.49.3",
     "ws": "^8.18.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       socket.io-client:
         specifier: ^4.8.1
         version: 4.8.3
+      viem:
+        specifier: ^2.49.3
+        version: 2.49.3(typescript@6.0.3)
       ws:
         specifier: ^8.18.0
         version: 8.21.0
@@ -1220,14 +1223,6 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
-  ox@0.11.1:
-    resolution: {integrity: sha512-1l1gOLAqg0S0xiN1dH5nkPna8PucrZgrIJOfS49MLNiMevxu07Iz4ZjuJS9N+xifvT+PsZyIptS7WHM8nC+0+A==}
-    peerDependencies:
-      typescript: '>=5.4.0'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
   ox@0.14.20:
     resolution: {integrity: sha512-rby38C3nDn8eQkf29Zgw4hkCZJ64Qqi0zRPWL8ENUQ7JVuoITqrVtwWQgM/He19SCMUEc7hS/Sjw0jIOSLJhOw==}
     peerDependencies:
@@ -1456,14 +1451,6 @@ packages:
 
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
-
-  viem@2.43.3:
-    resolution: {integrity: sha512-zM251fspfSjENCtfmT7cauuD+AA/YAlkFU7cksdEQJxj7wDuO0XFRWRH+RMvfmTFza88B9kug5cKU+Wk2nAjJg==}
-    peerDependencies:
-      typescript: '>=5.0.4'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
 
   viem@2.49.3:
     resolution: {integrity: sha512-FlIXd2kRygDxJtvjtPp74vjmyOKMjKlXXgTNdMxr8h3kcDrQ4bYb9q1MpSWyCVa3L2NJc9gSv+u8HcHYIZQUkw==}
@@ -2123,7 +2110,7 @@ snapshots:
       '@ethersproject/wallet': 5.8.0
       ethers: 5.8.0
       tslib: 2.8.1
-      viem: 2.43.3(typescript@6.0.3)
+      viem: 2.49.3(typescript@6.0.3)
     transitivePeerDependencies:
       - bufferutil
       - typescript
@@ -2742,21 +2729,6 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
-  ox@0.11.1(typescript@6.0.3):
-    dependencies:
-      '@adraffy/ens-normalize': 1.11.1
-      '@noble/ciphers': 1.3.0
-      '@noble/curves': 1.9.1
-      '@noble/hashes': 1.8.0
-      '@scure/bip32': 1.7.0
-      '@scure/bip39': 1.6.0
-      abitype: 1.2.3(typescript@6.0.3)
-      eventemitter3: 5.0.1
-    optionalDependencies:
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - zod
-
   ox@0.14.20(typescript@6.0.3):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
@@ -3039,23 +3011,6 @@ snapshots:
   undici-types@6.19.8: {}
 
   undici-types@7.16.0: {}
-
-  viem@2.43.3(typescript@6.0.3):
-    dependencies:
-      '@noble/curves': 1.9.1
-      '@noble/hashes': 1.8.0
-      '@scure/bip32': 1.7.0
-      '@scure/bip39': 1.6.0
-      abitype: 1.2.3(typescript@6.0.3)
-      isows: 1.0.7(ws@8.18.3)
-      ox: 0.11.1(typescript@6.0.3)
-      ws: 8.18.3
-    optionalDependencies:
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-      - zod
 
   viem@2.49.3(typescript@6.0.3):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: true

--- a/src/exchanges/polymarket/polymarket.ts
+++ b/src/exchanges/polymarket/polymarket.ts
@@ -1,5 +1,7 @@
 import { AssetType, ClobClient, Side } from '@polymarket/clob-client';
-import { Wallet } from 'ethers';
+import { createWalletClient, http, type WalletClient } from 'viem';
+import { privateKeyToAccount } from 'viem/accounts';
+import { polygon, polygonAmoy } from 'viem/chains';
 import { Exchange, type ExchangeConfig } from '../../core/exchange.js';
 import {
   AuthenticationError,
@@ -38,7 +40,7 @@ export class Polymarket extends Exchange {
   readonly name = 'Polymarket';
 
   private clobClient: ClobClient | null = null;
-  private wallet: Wallet | null = null;
+  private walletClient: WalletClient | null = null;
   private address: string | null = null;
   private clobClientAuthenticated = false;
   private authConfig: { chainId: number; signatureType: number; funder?: string } | null = null;
@@ -64,25 +66,27 @@ export class Polymarket extends Exchange {
       if (!config.privateKey) {
         return;
       }
-      this.wallet = new Wallet(config.privateKey);
+      const account = privateKeyToAccount(config.privateKey as `0x${string}`);
+      const chain = chainId === 80002 ? polygonAmoy : polygon;
+      this.walletClient = createWalletClient({ account, chain, transport: http() });
       this.clobClient = new ClobClient(
         CLOB_URL,
         chainId,
-        this.wallet,
+        this.walletClient,
         undefined,
         signatureType,
         config.funder
       );
 
       this.authConfig = { chainId, signatureType, funder: config.funder };
-      this.address = this.wallet.address;
+      this.address = account.address;
     } catch (error) {
       throw new AuthenticationError(`Failed to initialize CLOB client: ${error}`);
     }
   }
 
   private async ensureAuthenticated(): Promise<ClobClient> {
-    if (!this.clobClient || !this.wallet || !this.authConfig) {
+    if (!this.clobClient || !this.walletClient || !this.authConfig) {
       throw new AuthenticationError('CLOB client not initialized. Private key required.');
     }
 
@@ -99,7 +103,7 @@ export class Polymarket extends Exchange {
     this.clobClient = new ClobClient(
       CLOB_URL,
       this.authConfig.chainId,
-      this.wallet,
+      this.walletClient,
       creds,
       this.authConfig.signatureType,
       this.authConfig.funder

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,14 +15,11 @@
     "sourceMap": true,
     "outDir": "./dist",
     "rootDir": "./src",
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["./src/*"]
-    },
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedIndexedAccess": true
+    "noUncheckedIndexedAccess": true,
+    "ignoreDeprecations": "6.0"
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "tests", "examples"]


### PR DESCRIPTION
## Summary

Restore CI on `main`, which has been red since a chain of dependency updates broke the workflow file, the install step, and the type/build steps.

The four commits in this PR are minimal, logically separated fixes — no behavior changes outside the Polymarket adapter, whose internal signer was forced to change by `@polymarket/clob-client@5.x`.

## Problem

`main` currently fails CI for **four independent reasons**, each introduced by a recently merged auto-update PR:

1. **Workflow file rejected by GitHub Actions**
   Commit [`0f425d1`](https://github.com/gtg7784/dr-manhattan-ts/commit/0f425d1) added a `permissions` block to `.github/workflows/ci.yml` with mis-indented YAML, producing:
   ```
   Invalid workflow file
   (Line: 10, Col: 3): Unexpected value 'contents'
   (Line: 10, Col: 13): Unexpected value 'read'
   ```
   No jobs ran at all.

2. **`pnpm install --frozen-lockfile` exit code 1**
   After PR #44 bumped `pnpm` to v11 (`strictDepBuilds=true` by default), unreviewed build scripts fail the install:
   ```
   [ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: esbuild@0.27.2, esbuild@0.27.7
   Process completed with exit code 1.
   ```
   `esbuild` ships native binaries that `tsup` needs at build time, so it must be allow-listed in `pnpm-workspace.yaml` under the new `allowBuilds` setting (the old `package.json` `pnpm.onlyBuiltDependencies` field is no longer read by pnpm v11).

3. **`pnpm typecheck` and `pnpm build` (dts) fail with TS 6.0 deprecations**
   TypeScript 6 deprecates `baseUrl` (removed in TS 7):
   ```
   tsconfig.json(18,5): error TS5101: Option 'baseUrl' is deprecated and
   will stop functioning in TypeScript 7.0.
   ```
   The `@/*` alias was unused anywhere in `src/`, `tests/`, or `examples/`.

4. **`polymarket.ts` no longer type-checks against `@polymarket/clob-client@5.x`**
   PR #29 bumped `clob-client` to v5, whose `ClobSigner` is now `EthersSigner | WalletClient` where `EthersSigner` requires the legacy `_signTypedData` method (ethers v5). The project uses ethers v6 (`signTypedData`, no underscore), so:
   ```
   src/exchanges/polymarket/polymarket.ts(71,9): error TS2345:
   Argument of type 'Wallet' is not assignable to parameter of type
   'ClobSigner | undefined'.
   ```
   This breaks both `pnpm typecheck` and the `tsup` dts build (no `dist/index.d.ts` is produced).

## Changes

Each issue is addressed in its own commit:

1. **`fix(ci): correct permissions block indentation in ci.yml`**
   Move `permissions:` out from under `pull_request:` and place it at the top level alongside `on:` / `jobs:`.

2. **`chore(workspace): allow esbuild build scripts for pnpm v11`**
   Commit `pnpm-workspace.yaml` with `allowBuilds.esbuild: true` (replacing the placeholder pnpm v11 auto-wrote on first install).

3. **`chore(tsconfig): drop deprecated baseUrl/paths, silence TS 6.0 warning`**
   - Remove `baseUrl` (deprecated, removed in TS 7).
   - Remove `paths` (the `@/*` alias was unused).
   - Add `ignoreDeprecations: "6.0"` because `tsup`'s internal dts worker re-injects `baseUrl` against its synthesized tsconfig.

4. **`refactor(polymarket): migrate ClobClient signer to viem WalletClient`**
   - Add `viem ^2.46.3` as a direct dependency (matches the version range `@polymarket/clob-client` already pulls in).
   - Replace `new Wallet(privateKey)` with `privateKeyToAccount` + `createWalletClient`, mapping the configured `chainId` to `polygon` / `polygonAmoy`.
   - Pass the resulting `WalletClient` to `ClobClient` in both `initializeClobClient` and `ensureAuthenticated`.
   - Read `this.address` from `account.address` instead of `wallet.address`.
   - The external Polymarket API (constructor signature, exposed methods) is unchanged. Other exchanges (`limitless`, `opinion`, `predictfun`) keep using ethers.

## Testing

All CI steps now exit `0` locally:

| Step              | Exit |
|-------------------|------|
| `pnpm install --frozen-lockfile` | 0 |
| `pnpm lint`       | 0 |
| `pnpm typecheck`  | 0 |
| `pnpm test:run`   | 0 (83 / 83 passing) |
| `pnpm build`      | 0 (`dist/index.js` + `dist/index.d.ts` both emitted) |

Polymarket tests (`tests/polymarket.mock.test.ts`) do not mock the underlying signer, so the migration does not require test updates.
